### PR TITLE
support ALL image types supported by gd

### DIFF
--- a/phash.php
+++ b/phash.php
@@ -51,21 +51,25 @@ class Phash{
     public function getHash($filepath)
     {
         $scale = 8;//todo, allow scale specification
-        try
-        {
-            $img = imagecreatefrompng($filepath);
-        }
-        catch (exception $e)
-        {
-            try
-            {
-                $img = imagecreatefromjpeg($filepath);
-            }
-            catch (exception $f)
-            {
-                return 'Image could not be processed. Only JPG/PNG supported';
-            }
-        }
+		$img = file_get_contents ( $filepath );
+		if (! $img) {
+			return 'failed to load ' . $filepath;
+		}
+		$img = imagecreatefromstring ( $img );
+		if (! $img) {
+			// error, unsupported format.
+			$supportedFormats = '';
+			$needle = 'Support';
+			$needleLen = strlen ( $needle );
+			foreach ( gd_info () as $key => $val ) {
+				if (! $val || strlen ( $key ) <= $needleLen || substr ( $key, - $needleLen ) !== $needle) {
+					continue;
+				}
+				$supportedFormats .= trim ( substr ( $key, 0, strlen ( $key ) - $needleLen ) ) . ', ';
+			}
+			$supportedFormats = rtrim ( $supportedFormats, ', ' );
+			return 'the image format is not supported. supported formats: ' . $supportedFormats;
+		}
         $averageValue = 0;
         for ($y = 0; $y < $scale; $y++)
         {


### PR DESCRIPTION
what is supported is decided at php libgd compile time, which may include GIF, JPEG, PNG, WBMP, GD, GD2, XMB, webp, and maybe others. this code is also future proof, in that it will automatically support new formats whenever they're implemented in gd in the future

(personally, i prefer to throw exceptions rather than returning error strings, but that's for another discussion)